### PR TITLE
Fixed bencode encoding bug with long types

### DIFF
--- a/rtorrent/lib/bencode.py
+++ b/rtorrent/lib/bencode.py
@@ -267,9 +267,7 @@ def _encode_dict(data):
 def encode(data):
     if isinstance(data, bool):
         return False
-    elif isinstance(data, int):
-        return _encode_int(data)
-    elif isinstance(data, long):
+    elif isinstance(data, (int, long)):
         return _encode_int(data)
     elif isinstance(data, bytes):
         return _encode_string(data)

--- a/rtorrent/lib/bencode.py
+++ b/rtorrent/lib/bencode.py
@@ -269,6 +269,8 @@ def encode(data):
         return False
     elif isinstance(data, int):
         return _encode_int(data)
+    elif isinstance(data, long):
+        return _encode_int(data)
     elif isinstance(data, bytes):
         return _encode_string(data)
     elif isinstance(data, _VALID_STRING_TYPES):

--- a/rtorrent/lib/torrentparser.py
+++ b/rtorrent/lib/torrentparser.py
@@ -90,10 +90,10 @@ class TorrentParser():
     def _calc_info_hash(self):
         self.info_hash = None
         if "info" in self._torrent_decoded.keys():
-                info_encoded = bencode.encode(self._torrent_decoded["info"])
+            info_encoded = bencode.encode(self._torrent_decoded["info"])
 
-                if info_encoded:
-                    self.info_hash = hashlib.sha1(info_encoded).hexdigest().upper()
+            if info_encoded:
+                self.info_hash = hashlib.sha1(info_encoded).hexdigest().upper()
 
         return(self.info_hash)
 


### PR DESCRIPTION
This fixes a bug where info_hash fails to calculate when parsing a torrent, this is caused by the bencode library not supporting encoding of long number types when torrents have files over 2GB.

I'm unsure how this hasn't been spotted until now...

Noticed you pulled in my other changes, have been meaning to submit a PR upstream but keep forgetting about it. I'll try to get future changes upstream faster.
