### PR TITLE
Fix ExpatError since dicts don't have a stable order

### DIFF
--- a/rtorrent/lib/xmlrpc/scgi.py
+++ b/rtorrent/lib/xmlrpc/scgi.py
@@ -118,8 +118,8 @@ class SCGITransport(xmlrpclib.Transport):
 
     def single_request(self, host, handler, request_body, verbose=0):
         # Add SCGI headers to the request.
-        headers = {'CONTENT_LENGTH': str(len(request_body)), 'SCGI': '1'}
-        header = '\x00'.join(('%s\x00%s' % item for item in headers.items())) + '\x00'
+        headers = [('CONTENT_LENGTH', str(len(request_body))), ('SCGI', '1')]
+        header = '\x00'.join(['%s\x00%s' % (key, value) for key, value in headers]) + '\x00'
         header = '%d:%s' % (len(header), header)
         request_body = '%s,%s' % (header, request_body)
 


### PR DESCRIPTION
rtorrent expects the CONTENT_LENGTH header to come directly after the header length (see https://github.com/rakshasa/rtorrent/blob/d396c8e058d7665f7bcf85fc79f44030e5269480/src/rpc/scgi_task.cc#L143 ). However, as Python's dictionaries are unordered, the SCGI header may appear first, causing the ExpatError. This commit fixes the issue by using a list of tuples instead of a dict.
