### PR TITLE
Add support for d.tracker.insert

### DIFF
--- a/rtorrent/torrent.py
+++ b/rtorrent/torrent.py
@@ -350,7 +350,7 @@ class Torrent:
 
         @return: if successful, 0
         @rtype: int
-        """"
+        """
         m = rtorrent.rpc.Multicall(self)
         self.multicall_add(m, "d.tracker.insert", group, tracker)
 

--- a/rtorrent/torrent.py
+++ b/rtorrent/torrent.py
@@ -338,6 +338,24 @@ class Torrent:
         else:
             return p.view.set_not_visible(self.info_hash, view)
 
+    def add_tracker(self, group, tracker):
+        """
+        Add tracker to torrent
+
+        @param group: The group to add the tracker to
+        @type group: int
+
+        @param tracker: The tracker url
+        @type tracker: str
+
+        @return: if successful, 0
+        @rtype: int
+        """"
+        m = rtorrent.rpc.Multicall(self)
+        self.multicall_add(m, "d.tracker.insert", group, tracker)
+
+        return (m.call()[-1])
+
     ############################################################################
     # CUSTOM METHODS (Not part of the official rTorrent API)
     ##########################################################################

--- a/rtorrent/tracker.py
+++ b/rtorrent/tracker.py
@@ -67,6 +67,21 @@ class Tracker:
 
         multicall.call()
 
+    def append_tracker(self, tracker):
+        """
+        Append tracker to current tracker group
+
+        @param tracker: The tracker url
+        @type tracker: str
+
+        @return: if successful, 0
+        @rtype: int
+        """"
+        m = rtorrent.rpc.Multicall(self)
+        self.multicall_add(m, "d.tracker.insert", self.index, tracker)
+
+        return (m.call()[-1])
+
 methods = [
     # RETRIEVERS
     Method(Tracker, 'is_enabled', 't.is_enabled', boolean=True),

--- a/rtorrent/tracker.py
+++ b/rtorrent/tracker.py
@@ -76,7 +76,7 @@ class Tracker:
 
         @return: if successful, 0
         @rtype: int
-        """"
+        """
         m = rtorrent.rpc.Multicall(self)
         self.multicall_add(m, "d.tracker.insert", self.index, tracker)
 


### PR DESCRIPTION
d.tracker.insert was added in rtorrent 0.9.2. I couldn't find an easy way call it manually so I added 2 functions with documentation: torrent.add_tracker and tracker.append_tracker
